### PR TITLE
Added ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ vendor/
 .phpunit.result.cache
 .phpunit.cache
 coverage
+/qdrant_storage
+/composer.lock
+/.idea


### PR DESCRIPTION
Just a few ignores that I think we need. `qdrant_storage` is the folder used by Qdrant [Quickstart Guide](https://qdrant.tech/documentation/quick-start/). `.idea` is for my IDE and `composer.lock` is useful too.