### PR TITLE
Added `score_threshold` support

### DIFF
--- a/src/Models/Request/RecommendRequest.php
+++ b/src/Models/Request/RecommendRequest.php
@@ -16,6 +16,8 @@ class RecommendRequest
     protected array $negative;
     protected ?string $using = null;
     protected ?int $limit = null;
+    protected ?int $offset = null;
+    private ?float $scoreThreshold = null;
 
     public function __construct(array $positive, array $negative = [])
     {
@@ -26,6 +28,13 @@ class RecommendRequest
     public function setFilter(Filter $filter): static
     {
         $this->filter = $filter;
+
+        return $this;
+    }
+
+    public function setScoreThreshold(float $scoreThreshold): static
+    {
+        $this->scoreThreshold = $scoreThreshold;
 
         return $this;
     }
@@ -44,6 +53,13 @@ class RecommendRequest
         return $this;
     }
 
+    public function setOffset(int $offset): static
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         $body = [
@@ -54,11 +70,17 @@ class RecommendRequest
         if ($this->filter !== null) {
             $body['filter'] = $this->filter->toArray();
         }
+        if($this->scoreThreshold) {
+            $body['score_threshold'] = $this->scoreThreshold;
+        }
         if ($this->using) {
             $body['using'] = $this->using;
         }
         if ($this->limit) {
             $body['limit'] = $this->limit;
+        }
+        if ($this->offset) {
+            $body['offset'] = $this->offset;
         }
 
         return $body;

--- a/src/Models/Request/RecommendRequest.php
+++ b/src/Models/Request/RecommendRequest.php
@@ -17,7 +17,7 @@ class RecommendRequest
     protected ?string $using = null;
     protected ?int $limit = null;
     protected ?int $offset = null;
-    private ?float $scoreThreshold = null;
+    protected ?float $scoreThreshold = null;
 
     public function __construct(array $positive, array $negative = [])
     {

--- a/src/Models/Request/SearchRequest.php
+++ b/src/Models/Request/SearchRequest.php
@@ -26,9 +26,9 @@ class SearchRequest
 
     protected bool|array|null $withPayload = null;
 
-    public function __construct(VectorStruct $vector)
-    private ?float $scoreThreshold = null;
+    protected ?float $scoreThreshold = null;
 
+    public function __construct(VectorStruct $vector)
     {
         $this->vector = $vector;
     }

--- a/src/Models/Request/SearchRequest.php
+++ b/src/Models/Request/SearchRequest.php
@@ -27,6 +27,8 @@ class SearchRequest
     protected bool|array|null $withPayload = null;
 
     public function __construct(VectorStruct $vector)
+    private ?float $scoreThreshold = null;
+
     {
         $this->vector = $vector;
     }
@@ -34,6 +36,13 @@ class SearchRequest
     public function setFilter(Filter $filter): static
     {
         $this->filter = $filter;
+
+        return $this;
+    }
+
+    public function setScoreThreshold(float $scoreThreshold): static
+    {
+        $this->scoreThreshold = $scoreThreshold;
 
         return $this;
     }
@@ -80,6 +89,9 @@ class SearchRequest
         ];
         if ($this->filter !== null) {
             $body['filter'] = $this->filter->toArray();
+        }
+        if($this->scoreThreshold) {
+            $body['score_threshold'] = $this->scoreThreshold;
         }
         if ($this->params) {
             $body['params'] = $this->params;

--- a/tests/Integration/Endpoints/Collections/SearchTest.php
+++ b/tests/Integration/Endpoints/Collections/SearchTest.php
@@ -119,7 +119,7 @@ class SearchTest extends AbstractIntegration
         $this->assertEquals('ok', $responseWithThreshold['status']);
 
         // Assert that the result count is higher or the same when no score threshold is used
-        $this->assertGreaterThanOrEqual(
+        $this->assertGreaterThan(
             count($responseWithThreshold['result']),
             count($responseWithoutThreshold['result']),
             'The result count should be higher or the same when no score threshold is used'


### PR DESCRIPTION
Fairly straightforward. Qdrant allows you to specify a `score_threshold` for search requests and recommended requests.

https://qdrant.tech/documentation/concepts/search/#filtering-results-by-score