### PR TITLE
Check for empty filters

### DIFF
--- a/src/Models/Request/RecommendRequest.php
+++ b/src/Models/Request/RecommendRequest.php
@@ -51,7 +51,7 @@ class RecommendRequest
             'negative' => $this->negative,
         ];
 
-        if ($this->filter !== null) {
+        if ($this->filter !== null && $this->filter->toArray()) {
             $body['filter'] = $this->filter->toArray();
         }
         if ($this->using) {

--- a/src/Models/Request/SearchRequest.php
+++ b/src/Models/Request/SearchRequest.php
@@ -78,7 +78,7 @@ class SearchRequest
         $body = [
             'vector' => $this->vector->toSearch(),
         ];
-        if ($this->filter !== null) {
+        if ($this->filter !== null && $this->filter->toArray()) {
             $body['filter'] = $this->filter->toArray();
         }
         if ($this->params) {

--- a/tests/Integration/Endpoints/Collections/SearchTest.php
+++ b/tests/Integration/Endpoints/Collections/SearchTest.php
@@ -65,7 +65,6 @@ class SearchTest extends AbstractIntegration
      */
     public function testSearchPoint(VectorStruct $vector): void
     {
-
         $searchRequest = (new SearchRequest($vector))
             ->setLimit(3)
             ->setFilter(
@@ -81,6 +80,26 @@ class SearchTest extends AbstractIntegration
         $response = $this->getCollections('sample-collection')->points()->search($searchRequest);
 
         $this->assertEquals('ok', $response['status']);
+        $this->assertCount(1, $response['result']);
+    }
+
+    /**
+     * @dataProvider searchQueryProvider
+     */
+    public function testSearchPointEmptyFilter(VectorStruct $vector): void
+    {
+        $searchRequest = (new SearchRequest($vector))
+            ->setLimit(3)
+            ->setFilter(new Filter())
+            ->setParams([
+                'hnsw_ef' => 128,
+                'exact' => false,
+            ]);
+
+        $response = $this->getCollections('sample-collection')->points()->search($searchRequest);
+
+        $this->assertEquals('ok', $response['status']);
+        $this->assertCount(2, $response['result']);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Passing an empty array causes an error with the Qdrant server, so this is just one last sanity check.

It's foreseeable that a developer might construct a `Filter` over a series of steps, and in the end, have an empty Filter object.  You can see the test I added to see what this PR solves.