### PR TITLE
The value of the HNSW configuration parameter M can be zero

### DIFF
--- a/src/Models/Request/CollectionConfig/HnswConfig.php
+++ b/src/Models/Request/CollectionConfig/HnswConfig.php
@@ -80,7 +80,7 @@ class HnswConfig implements RequestModel
     public function toArray(): array
     {
         $data = [];
-        if ($this->m) {
+        if ($this->m !== null) {
             $data['m'] = $this->m;
         }
         if ($this->efConstruct) {

--- a/tests/Unit/Models/Request/CollectionConfig/HnswConfigTest.php
+++ b/tests/Unit/Models/Request/CollectionConfig/HnswConfigTest.php
@@ -28,6 +28,15 @@ class HnswConfigTest extends TestCase
         ], $config->toArray());
     }
 
+    public function testWithZeroM(): void
+    {
+        $config = (new HnswConfig())->setM(0);
+
+        $this->assertEquals([
+            'm' => 0
+        ], $config->toArray());
+    }
+
     public function testWithInvalidM(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Models/Request/CreateCollectionTest.php
+++ b/tests/Unit/Models/Request/CreateCollectionTest.php
@@ -193,6 +193,31 @@ class CreateCollectionTest extends TestCase
         );
     }
 
+    public function testCreateCollectionWithHnswConfigAndZeroM(): void
+    {
+        $collection = new CreateCollection();
+        $collection->addVector(new VectorParams(1024, VectorParams::DISTANCE_COSINE));
+        $diff = (new HnswConfig())
+            ->setM(0)
+            ->setPayloadM(1);
+
+        $collection->setHnswConfig($diff);
+
+        $this->assertEquals(
+            [
+                'vectors' => [
+                    'size' => '1024',
+                    'distance' => 'Cosine'
+                ],
+                'hnsw_config' => [
+                    'm' => 0,
+                    'payload_m' => 1,
+                ]
+            ],
+            $collection->toArray()
+        );
+    }
+
     public function testCreateCollectionWithWalConfig(): void
     {
         $collection = new CreateCollection();

--- a/tests/Unit/Models/Request/UpdateCollectionTest.php
+++ b/tests/Unit/Models/Request/UpdateCollectionTest.php
@@ -58,6 +58,22 @@ class UpdateCollectionTest extends TestCase
         );
     }
 
+    public function testUpdateCollectionWithHnswConfigAndZeroM(): void
+    {
+        $collection = new UpdateCollection();
+        $collection->setHnswConfig((new HnswConfig())->setM(0)->setEfConstruct(5));
+
+        $this->assertEquals(
+            [
+                'hnsw_config' => [
+                    'm' => 0,
+                    'ef_construct' => 5
+                ],
+            ],
+            $collection->toArray()
+        );
+    }
+
     public function testUpdateCollectionWithQuantizationConfig(): void
     {
         $collection = new UpdateCollection();


### PR DESCRIPTION
Hi!

I tried to implement the configuration trick from [the documentation](https://qdrant.tech/documentation/guides/multiple-partitions/#calibrate-performance) and realized that when I set M to 0 in the HNSW configuration, in the new collection I get the default M value (16 in my case).

PR will fix it