### PR TITLE
Make package compatible with PHP 8.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
           - php-version: '8.1'
           - php-version: '8.2'
           - php-version: '8.3'
+          - php-version: '8.4'
     services:
       qdrant:
         image: qdrant/qdrant

--- a/src/Endpoints/Collections/Points.php
+++ b/src/Endpoints/Collections/Points.php
@@ -50,7 +50,7 @@ class Points extends AbstractEndpoint
     /**
      * @throws InvalidArgumentException
      */
-    public function scroll(Filter|ScrollRequest $scrollParams = null, array $queryParams = []): Response
+    public function scroll(Filter|ScrollRequest|null $scrollParams = null, array $queryParams = []): Response
     {
         $body = [];
         if ($scrollParams instanceof Filter) {
@@ -133,7 +133,7 @@ class Points extends AbstractEndpoint
     /**
      * @throws InvalidArgumentException
      */
-    public function count(Filter $filter = null, $exact = false): Response
+    public function count(?Filter $filter = null, $exact = false): Response
     {
         $body = [
             'exact' => $exact,

--- a/src/Endpoints/Collections/Points/Payload.php
+++ b/src/Endpoints/Collections/Points/Payload.php
@@ -37,10 +37,11 @@ class Payload extends AbstractEndpoint
      * @param array $points
      * @param array $keys
      * @param Filter|null $filter
+     * @param array $queryParams
      * @return Response
      * @throws InvalidArgumentException
      */
-    public function delete(array $points, array $keys, Filter $filter = null, array $queryParams = []): Response
+    public function delete(array $points, array $keys, ?Filter $filter = null, array $queryParams = []): Response
     {
         $data = [
             'points' => $points,

--- a/src/Endpoints/Collections/Snapshots.php
+++ b/src/Endpoints/Collections/Snapshots.php
@@ -68,7 +68,7 @@ class Snapshots extends AbstractEndpoint
     /**
      * @throws InvalidArgumentException
      */
-    public function recover(bool $wait = null): Response
+    public function recover(?bool $wait = null): Response
     {
         return $this->client->execute(
             $this->createRequest(

--- a/src/Http/Builder.php
+++ b/src/Http/Builder.php
@@ -15,7 +15,7 @@ use Qdrant\Config;
 class Builder
 {
     protected ?ClientInterface $client;
-    public function __construct(ClientInterface $client = null) {
+    public function __construct(?ClientInterface $client = null) {
         $this->client = $client ?: Psr18ClientDiscovery::find();
     }
 

--- a/src/Models/MultiVectorStruct.php
+++ b/src/Models/MultiVectorStruct.php
@@ -29,7 +29,7 @@ class MultiVectorStruct implements VectorStructInterface
         return array_key_first($this->vectors);
     }
 
-    public function toSearchArray(string $name = null): array
+    public function toSearchArray(?string $name = null): array
     {
         // Throw an error if no name is given
         if ($name === null) {

--- a/src/Models/Request/CreateCollection.php
+++ b/src/Models/Request/CreateCollection.php
@@ -37,7 +37,7 @@ class CreateCollection implements RequestModel
 
     protected ?QuantizationConfig $quantizationConfig = null;
 
-    public function addVector(VectorParams $vectorParams, string $name = null): CreateCollection
+    public function addVector(VectorParams $vectorParams, ?string $name = null): CreateCollection
     {
         if ($name !== null) {
             $this->vectors[$name] = $vectorParams->toArray();

--- a/src/Models/Request/CreateIndex.php
+++ b/src/Models/Request/CreateIndex.php
@@ -11,7 +11,7 @@ class CreateIndex implements RequestModel
     protected string $fieldName;
     protected ?array $fieldSchema;
 
-    public function __construct(string $fieldName, array|string $fieldSchema = null)
+    public function __construct(string $fieldName, array|string|null $fieldSchema = null)
     {
         if (is_string($fieldSchema)) {
             $this->fieldSchema = [

--- a/src/Models/VectorStruct.php
+++ b/src/Models/VectorStruct.php
@@ -26,7 +26,7 @@ class VectorStruct implements VectorStructInterface
         return $this->name;
     }
 
-    public function toSearchArray(string $name = null): array
+    public function toSearchArray(?string $name = null): array
     {
         if ($this->isNamed()) {
             return [

--- a/src/Models/VectorStructInterface.php
+++ b/src/Models/VectorStructInterface.php
@@ -17,7 +17,7 @@ interface VectorStructInterface
      * @param string|null $name
      * @return array
      */
-    public function toSearchArray(string $name = null): array;
+    public function toSearchArray(?string $name = null): array;
 
     /**
      * Convert this vector an array for Point and PointsBatch.

--- a/src/Qdrant.php
+++ b/src/Qdrant.php
@@ -20,7 +20,7 @@ class Qdrant implements ClientInterface
     {
     }
 
-    public function collections(string $collectionName = null): Collections
+    public function collections(?string $collectionName = null): Collections
     {
         return (new Collections($this))->setCollectionName($collectionName);
     }

--- a/tests/Integration/AbstractIntegration.php
+++ b/tests/Integration/AbstractIntegration.php
@@ -40,7 +40,7 @@ abstract class AbstractIntegration extends TestCase
             ->addVector(new VectorParams(3, VectorParams::DISTANCE_COSINE), 'text');
     }
 
-    protected function createCollections($name, CreateCollection $withConfiguration = null): void
+    protected function createCollections($name, ?CreateCollection $withConfiguration = null): void
     {
         $this->collections = new Collections($this->client);
         $response = $this->collections->setCollectionName($name)


### PR DESCRIPTION
Hi! I have upgraded to PHP 8.4 in my project recently, and I noticed a few deprecation notices, e.g.,

```
Deprecated: Qdrant\Qdrant::collections(): Implicitly marking parameter $collectionName as nullable is deprecated, the explicit nullable type must be used instead in .../vendor/hkulekci/qdrant/src/Qdrant.php on line 23

Deprecated: Qdrant\Http\Builder::__construct(): Implicitly marking parameter $client as nullable is deprecated, the explicit nullable type must be used instead in .../vendor/hkulekci/qdrant/src/Http/Builder.php on line 18
```

RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

So I decided to fix the issues to get rid of notices. Changes are backward compatible.
I have also defined a job to run tests with PHP 8.4.

Let me know wdyt